### PR TITLE
fix: order of fetch array value

### DIFF
--- a/complex.rst
+++ b/complex.rst
@@ -63,7 +63,7 @@ Javaなどの配列は要素のすべての型は同じです。TypeScriptでは
    var other = smalls.slice(1);
 
    // 新: まとめて取り出し
-   const [smallCar, smallDog] = smalls;
+   const [smallAnimal, smallCar, essay] = smalls;
    // 新: 2番目以降の要素の取り出し
    const [, ...other] = smalls;
 


### PR DESCRIPTION
- `小動物` と `小型車` の配列から取り出す順序が逆かつ、 `小型犬` になっていたため修正
- コメントの「まとめて取り出し」に合わせて `小論文` の変数名を追加