### PR TITLE
add `word-break` property in basic CSS

### DIFF
--- a/docs/_static/basic.css
+++ b/docs/_static/basic.css
@@ -218,6 +218,7 @@ table.modindextable td {
 div.body {
     min-width: 450px;
     max-width: 800px;
+    word-break: break-word;
 }
 
 div.body p, div.body dd, div.body li, div.body blockquote {


### PR DESCRIPTION
以下のように長大なリンクに対して改行が行われていないため、ページの右側に余分な余白ができてしまっています。
タブレットのような横幅の短い端末でトップページを開くと、この右側の余白だけが表示されてしまい、何も文字が無いように見えてしまっていました。

![image](https://user-images.githubusercontent.com/36184621/60720482-e4c2dd80-9f65-11e9-8e4f-f6d76c5dec27.png)
