### PR TITLE
Reame `finally` to `finallyFunc`, for `finally` is reserved word

### DIFF
--- a/async.rst
+++ b/async.rst
@@ -184,14 +184,14 @@ TypeScriptで提供されている ``if`` や ``for`` 、 ``while`` などは関
    }
 
    // 必ず実行される
-   async function finally() {
+   async function finallyFunc() {
    }
 
    async function main(){
      if (Date.now() % 2 === 1) {
        await randomRun();
      }
-     await finally();
+     await finallyFunc();
    }
 
    main();


### PR DESCRIPTION
> 試しに、TypeScriptのPlayGroundで下記のコードを変換してみるとどうなるか見て見ると複雑さにひっくり返るでしょう。

と書かれていますが，予約語である`finally`が識別子として使われているため，実際にはコンパイルができません．`finallyFunc`と名前を変えてみました．