### PR TITLE
[fix] 記載順序の変更

### DIFF
--- a/complex.rst
+++ b/complex.rst
@@ -34,8 +34,8 @@ Javaなどの配列は要素のすべての型は同じです。TypeScriptでは
 .. code-block:: ts
 
    const movie: [string, number] = ['Gozilla', 1954];
-   // error TS2322: Type 'number' is not assignable to type 'string'.
    movie[0] = 2019;
+   // error TS2322: Type 'number' is not assignable to type 'string'.
 
 配列からのデータの取り出し
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
変数定義時に該当のエラーが発生するのではなく、
変数代入が行われたときにエラーが発生する、が正しいので記載順序のみ変更しました。